### PR TITLE
Fixed missing close parenthesis on line 65

### DIFF
--- a/src/rastrea2r/linux/rastrea2r_linux_v0.3.py
+++ b/src/rastrea2r/linux/rastrea2r_linux_v0.3.py
@@ -62,7 +62,7 @@ def yaradisk(path, server, rule, silent):
                                "module": 'yaradisk',
                                "hostname": os.uname()[1]}
                     if not silent:
-                        print(payload
+                        print(payload)
 
                     p=post('http://'+server+':'+str(server_port)+'/putfile', data=payload)
             except:


### PR DESCRIPTION
Line 65 of
src/rastrea2r/linux/rastrea2r_linux_v0.3.py

is missing a close parenthesis.